### PR TITLE
add remote user setup to allow multiple users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 packages.yml
 
 files/hosts.ini
+bluebox/files/hosts.txt
 **/*-ssh-key
 **/*-ssh-key.pub
 cluster-ssh-key

--- a/bluebox/Vagrantfile
+++ b/bluebox/Vagrantfile
@@ -28,6 +28,7 @@ Vagrant.configure(2) do |config|
       box.vm.provision "ansible" do |ansible|
         ansible.playbook = "dev/preprovision.yaml"
         ansible.groups = { "vagrant" => ["all"] }
+        ansible.extra_vars = { ansible_python_interpreter: "/usr/bin/python3" }
       end
 
       # box.vm.provision "ansible" do |ansible|

--- a/bluebox/ansible.cfg
+++ b/bluebox/ansible.cfg
@@ -1,5 +1,7 @@
 [defaults]
 retry_files_enabled = False
 deprecation_warnings = False
+host_key_checking = False
+ansible_python_interpreter=/usr/bin/python3
 [inventory]
 enable_plugins = ini, script, host_list, yaml, auto

--- a/bluebox/dev/preprovision.yaml
+++ b/bluebox/dev/preprovision.yaml
@@ -18,8 +18,8 @@
   connection: ssh
   user: vagrant
   pre_tasks:
-  - name: Make sure python package is installed (16.04 does not by default)
-    raw: bash -c "test -e /usr/bin/python || (apt -qqy update && apt install -qqy python3 python)"
+  - name: Make sure python3 package is installed (16.04 does not by default)
+    raw: bash -c "test -e /usr/bin/python3 || (apt -qqy update && apt install -qqy python3 python3-apt)"
     register: output
     changed_when: output.stdout != ""
 

--- a/bluebox/group_vars/nodes.yaml
+++ b/bluebox/group_vars/nodes.yaml
@@ -1,6 +1,5 @@
 ---
 ansible_connection: ssh
-ansible_user: ubuntu
 remote_code_path: ~/bluebox
 remote_data_path: ~/bluebox/data
 remote_results_path: ~/bluebox/results

--- a/bluebox/group_vars/presetup.yaml
+++ b/bluebox/group_vars/presetup.yaml
@@ -1,6 +1,5 @@
 ---
 ansible_connection: ssh
-ansible_user: ubuntu
 become: yes
 gather_facts: true
 common_apt_packages:
@@ -10,9 +9,10 @@ common_apt_packages:
   - sshpass
   - build-essential
   - python-setuptools
-  - python-apt
-  - python3-apt
   - python-dev
+  - python3-setuptools
+  - python3-distutils
+  - python3-apt
   - python3-dev
   - xz-utils
   - autoconf
@@ -27,14 +27,13 @@ common_apt_packages:
   - libgsl0-dev
   - rng-tools
   - uuid
+  - dstat
   - sysstat
+  - bash-completion
 common_pip_packages:
   - virtualenv
   - setuptools
   - wheel
-  - numpy
-  - pandas
-  - scipy
   - six
   - tox
   - jmespath

--- a/bluebox/includes/localhost.yaml
+++ b/bluebox/includes/localhost.yaml
@@ -16,7 +16,7 @@
 - name: Get latest GNU Parallel
   become: yes
   unarchive:
-    src: https://ftp.gnu.org/gnu/parallel/parallel-20200322.tar.bz2
+    src: https://ftp.gnu.org/gnu/parallel/parallel-20200922.tar.bz2
     # http://ftp.gnu.org/gnu/parallel/parallel-latest.tar.bz2
     dest: /usr/local
     remote_src: yes
@@ -50,7 +50,7 @@
   file:
     path: "/home/{{ ansible_user_id }}/.parallel/will-cite"
     state: touch
-    mode: '0664'
+    mode: "0664"
   ignore_errors: yes
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 

--- a/bluebox/includes/nodes.yaml
+++ b/bluebox/includes/nodes.yaml
@@ -3,13 +3,14 @@
 - name: Install common-packages
   apt:
     name: "{{ common_apt_packages }}"
+    update_cache: yes
 
 # Pip installation - assure actual versions
 - name: Get PIP installation
   get_url:
     url: "https://bootstrap.pypa.io/get-pip.py"
     dest: "/tmp/get-pip.py"
-    mode: '0777'
+    mode: "0777"
   register: getpip
 - name: Install PIP (Python 2)
   command:
@@ -33,10 +34,26 @@
     executable: /usr/local/bin/pip3
   ignore_errors: yes
 
+- name: Ansible config directory
+  become: yes
+  become_user: "{{ local_lab_user }}"
+  file:
+    path: "/home/{{ local_lab_user }}/.ansible"
+    state: directory
+    mode: "0755"
+
+- name: Ansible tmp directory
+  become: yes
+  become_user: "{{ local_lab_user }}"
+  file:
+    path: "/home/{{ local_lab_user }}/.ansible/tmp"
+    state: directory
+    mode: "0777"
+
 - name: Get latest GNU Parallel
   # become: yes
   unarchive:
-    src: https://ftp.gnu.org/gnu/parallel/parallel-20200322.tar.bz2
+    src: https://ftp.gnu.org/gnu/parallel/parallel-20200922.tar.bz2
     # http://ftp.gnu.org/gnu/parallel/parallel-latest.tar.bz2
     dest: /usr/local
     remote_src: yes
@@ -65,46 +82,52 @@
     filename: "{{ ansible_distribution_release }}-cran35"
 
 - name: Paralell rc directory
-  become: no
+  become: yes
+  become_user: "{{ local_lab_user }}"
   file:
-    path: "/home/{{ ansible_user }}/.parallel"
+    path: "/home/{{ local_lab_user }}/.parallel"
     state: directory
 
 - name: Paralell confirm
-  become: no
+  become: yes
+  become_user: "{{ local_lab_user }}"
   file:
-    path: "/home/{{ ansible_user }}/.parallel/will-cite"
+    path: "/home/{{ local_lab_user }}/.parallel/will-cite"
     state: touch
-    mode: '0664'
+    mode: "0664"
 
 - name: Get miniconda script
   get_url:
     url: "https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh"
     dest: /tmp/miniconda.sh
-    mode: '0777'
+    mode: "0777"
 
 - name: Install Miniconda
-  become: no
+  become: yes
+  become_user: "{{ local_lab_user }}"
   command:
-    cmd: bash /tmp/miniconda.sh -b -p /home/{{ ansible_user }}/miniconda
-    creates: /home/{{ ansible_user }}/miniconda/bin/conda
+    cmd: bash /tmp/miniconda.sh -b -p /home/{{ local_lab_user }}/miniconda
+    creates: /home/{{ local_lab_user }}/miniconda/bin/conda
 
 - name: Install base condarc
-  become: no
-  copy: src=condarc dest=/home/{{ ansible_user }}/.condarc
+  become: yes
+  become_user: "{{ local_lab_user }}"
+  copy: src=condarc dest=/home/{{ local_lab_user }}/.condarc
 
 - name: Add miniconda to the PATH
-  become: no
+  become: yes
+  become_user: "{{ local_lab_user }}"
   lineinfile:
-    dest: "/home/{{ ansible_user }}/.bashrc"
-    line: export PATH=/home/{{ ansible_user }}/miniconda/bin:$PATH
+    dest: "/home/{{ local_lab_user }}/.bashrc"
+    line: export PATH=/home/{{ local_lab_user }}/miniconda/bin:$PATH
     state: present
 
 - name: Add bluebox env SCIBOX_HOME
-  become: no
+  become: yes
+  become_user: "{{ local_lab_user }}"
   lineinfile:
-    dest: "/home/{{ ansible_user }}/.bashrc"
-    line: export SCIBOX_HOME=/home/{{ ansible_user }}/bluebox
+    dest: "/home/{{ local_lab_user }}/.bashrc"
+    line: export SCIBOX_HOME=/home/{{ local_lab_user }}/bluebox
     state: present
 
 - name: Add BlueBoxMon
@@ -112,11 +135,12 @@
   copy:
     src: blueboxmon
     dest: /usr/local/bin/blueboxmon
-    mode: '0755'
+    mode: "0755"
 
 - name: Add bluebox to the PATH
-  become: no
+  become: yes
+  become_user: "{{ local_lab_user }}"
   lineinfile:
-    dest: "/home/{{ ansible_user }}/.bashrc"
-    line: export PATH=/home/{{ ansible_user }}/bluebox:$PATH
+    dest: "/home/{{ local_lab_user }}/.bashrc"
+    line: export PATH=/home/{{ local_lab_user }}/bluebox:$PATH
     state: present

--- a/bluebox/playbook.yaml
+++ b/bluebox/playbook.yaml
@@ -6,7 +6,8 @@
     - name: "Add IAAS nodes from {{ hosts_path | default('hosts.txt') }} to Ansible inventory"
       add_host:
         hostname: "{{ item.split('@')[1].split(':')[0] if '@' in item else item.split('/')[1].split(':')[0] }}"
-        ansible_user: ubuntu
+        ansible_user: "{{ ansible_user_id }}"
+        ansible_ssh_user: "{{ ansible_user_id }}"
         groups: ["all", "nodes"]
         ansible_ssh_private_key_file: "files/{{ ansible_user_id }}-ssh-key"
         local_lab_user: "{{ ansible_user_id }}"
@@ -16,7 +17,7 @@
 
 - hosts: nodes
   become: yes
-  become_user: ubuntu
+  become_user: "{{ local_lab_user }}"
   gather_facts: false
   tasks:
     - name: Setup folders

--- a/bluebox/setup.yaml
+++ b/bluebox/setup.yaml
@@ -24,10 +24,12 @@
     - name: "Add IAAS nodes from {{ hosts_path | default('hosts.txt') }} to Ansible inventory"
       add_host:
         hostname: "{{ item.split('@')[1].split(':')[0] if '@' in item else item.split('/')[1].split(':')[0] }}"
-        ansible_user: ubuntu
-        groups: ["all", "nodes"]
+        ansible_user: "{{ ansible_user_id }}"
+        ansible_ssh_user: "{{ ansible_user_id }}"
         ansible_ssh_private_key_file: "files/{{ ansible_user_id }}-ssh-key"
         local_lab_user: "{{ ansible_user_id }}"
+        ansible_python_interpreter: "/usr/bin/python3"
+        groups: ["all", "nodes"]
       ignore_errors: yes
       with_lines: "cat ../{{ hosts_path | default('hosts.txt') }}"
       tags: always
@@ -35,10 +37,12 @@
       add_host:
         hostname: "{{ item.split('@')[1].split(':')[0] if '@' in item else item.split('/')[1].split(':')[0] }}"
         ansible_user: ubuntu
+        ansible_ssh_user: ubuntu
         ansible_ssh_pass: ubuntu
         local_lab_user: "{{ ansible_user_id }}"
-        ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
-        # ansible_ssh_common_args: '-o PubkeyAuthentication=no -o PasswordAuthentication=yes'
+        ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o IdentitiesOnly=yes"
+        ansible_python_interpreter: "/usr/bin/python3"
+        # ansible_ssh_common_args: "-o UserKnownHostsFile=/dev/null -o PasswordAuthentication=yes"
         groups: ["presetup"]
       ignore_errors: yes
       with_lines: "cat ../{{ hosts_path | default('hosts.txt') }}"
@@ -47,14 +51,52 @@
 # Prepare IAAS nodes
 - hosts: presetup
   tasks:
+    - name: Ensure group "bluebox" exists
+      become: yes
+      group:
+        name: bluebox
+        state: present
+    - name: Ensure user group exists
+      become: yes
+      group:
+        name: "{{ local_lab_user }}"
+        state: present
+    - name: Setup user
+      become: yes
+      user:
+        name: "{{ local_lab_user }}"
+        group: "{{ local_lab_user }}"
+        password: "{{ local_lab_user | password_hash('sha512') }}"
+        shell: /bin/bash
+        append: yes
+        groups:
+          - "sudo"
+          - "bluebox"
+          - "{{ local_lab_user }}"
+        comment: "bluebox user"
     - name: Set authorized key
+      become: yes
+      become_user: "{{ local_lab_user }}"
       authorized_key:
-        user: "{{ ansible_user }}"
+        user: "{{ local_lab_user }}"
         key: "{{ lookup('file', '{{ local_lab_user }}-ssh-key.pub') }}"
         state: present
         exclusive: no
         comment: "{{ local_lab_user }}@bluebox.iaas"
       tags: setupkeys
+    # - name: Set authorized key
+    #   authorized_key:
+    #     user: "{{ ansible_user }}"
+    #     key: "{{ lookup('file', '{{ local_lab_user }}-ssh-key.pub') }}"
+    #     state: present
+    #     exclusive: no
+    #     comment: "{{ local_lab_user }}@bluebox.iaas"
+    #   tags: setupkeys
+    - name: Set permissions
+      become: yes
+      copy:
+        content: "{{ local_lab_user }} ALL=(ALL) NOPASSWD:ALL"
+        dest: "/etc/sudoers.d/99-bluebox-{{ local_lab_user }}.conf"
 
 # Prepare IAAS nodes
 - hosts: nodes
@@ -65,6 +107,7 @@
       vars:
         possible_files:
           - "../packages.yml"
+          - "../packages.yaml"
           - "../example.packages.yml"
       tags: 'always'
   tasks:

--- a/bluebox/setup.yaml
+++ b/bluebox/setup.yaml
@@ -61,7 +61,7 @@
         - bluebox
         - "{{ local_lab_user }}"
         - docker
-      when: addgroups is not skipped and addgroups is successful
+      register: addgroups
     - name: Setup user
       become: yes
       user:
@@ -72,7 +72,6 @@
         append: yes
         groups:
           - sudo
-          - docker
           - bluebox
           - "{{ local_lab_user }}"
         comment: "bluebox user"

--- a/example.packages.yml
+++ b/example.packages.yml
@@ -7,6 +7,7 @@ python_pip_packages:
   - pysam
   - numpy
   - pandas
+  - scipy
   - memory-profiler
 r_packages: []
 conda_packages:


### PR DESCRIPTION
add user set up to allow multiple users on nodes:
- lab user will be created on remote machines
- ssh key will be generated per user
- miniconda is set up per user
- user is added to sudo and bluebox groups