### PR TITLE
add ppa key and repository configuration

### DIFF
--- a/bluebox/group_vars/presetup.yaml
+++ b/bluebox/group_vars/presetup.yaml
@@ -28,6 +28,11 @@ common_apt_packages:
   - rng-tools
   - uuid
   - sysstat
+  - apt-transport-https
+  - ca-certificates
+  - curl
+  - gnupg-agent
+  - software-properties-common
 common_pip_packages:
   - virtualenv
   - setuptools

--- a/bluebox/includes/packages.yaml
+++ b/bluebox/includes/packages.yaml
@@ -1,5 +1,31 @@
 ---
-- name: Install APT packages.
+- name: Add APT keys
+  apt_key:
+    url: "{{ item.url | default(item) }}"
+    id: "{{ item.id | default(omit) }}"
+    keyserver: "{{ item.keyserver | default(omit) }}"
+    keyring: "{{ item.keyring | default(omit) }}"
+    file: "{{ item.file | default(omit) }}"
+    data: "{{ item.data | default(omit) }}"
+    state: "{{ item.state | default('present') }}"
+  with_items: "{{ apt_keys | default([]) }}"
+  ignore_errors: yes
+
+# Use ansible_distribution_release variable in packages.yml instead of specific ubuntu version
+- name: Install APT repository
+  apt_repository:
+    repo: "{{ item.repo | default(item) }}"
+    filename: "{{ item.filename | default(omit) }}"
+    state: "{{ item.state | default('present') }}"
+    update_cache: "{{ item.update_cache | default('no') }}"
+  with_items: "{{ apt_repositories | default([]) }}"
+  ignore_errors: yes
+
+- name: Run apt-get update
+  apt:
+    update_cache: "yes"
+
+- name: Install APT packages
   apt:
     name: "{{ item.name | default(item) }}"
     state: "{{ item.state | default('present') }}"

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -69,3 +69,25 @@ No conda packages required:
 ```
 conda_packages: []
 ```
+
+# Docker Example
+
+Example of docker installation using packages.yml definition based on
+[Official docker installation guide for Ubuntu](https://docs.docker.com/engine/install/ubuntu/)
+shows how to correctly set apt keys and add official apt repository, to be able to install
+essential docker packages:
+
+```
+apt_keys:
+  - id: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
+    url: https://download.docker.com/linux/ubuntu/gpg
+
+apt_repositories:
+  - repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+    filename: "docker-engine"
+
+apt_packages:
+  - docker-ce
+  - docker-ce-cli
+  - containerd.io
+```


### PR DESCRIPTION
ppa key and repository configuration:
- allow users to define more advanced dependency setups when using apt packages
- add config example for setting up Docker on bluebox
- adding common packages needed for these setups